### PR TITLE
fix that rlim_max is always updated

### DIFF
--- a/src/trace.c
+++ b/src/trace.c
@@ -95,8 +95,8 @@ set_rlimit(struct ipft_symsdb *sdb)
     lim.rlim_cur += nfiles;
   }
 
-  if (lim.rlim_max != RLIM_INFINITY) {
-    lim.rlim_max += nfiles;
+  if (lim.rlim_cur > lim.rlim_max) {
+    lim.rlim_max = lim.rlim_cur;
   }
 
   error = setrlimit(RLIMIT_NOFILE, &lim);


### PR DESCRIPTION
## environment

```
$ cat /etc/lsb-release                      
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=20.04
DISTRIB_CODENAME=focal
DISTRIB_DESCRIPTION="Ubuntu 20.04 LTS"
$  sudo sysctl fs.nr_open
1048576
```

In my environment, ipft exited unsuccessfully because the value of rlim_max(1050763) is greater than fs.nr_open(1048576).

```
$ sudo strace -e "prlimit64" ipft -m 0xdeadbeef 
prlimit64(0, RLIMIT_MEMLOCK, {rlim_cur=RLIM64_INFINITY, rlim_max=RLIM64_INFINITY}, NULL) = 0
prlimit64(0, RLIMIT_NOFILE, NULL, {rlim_cur=1024, rlim_max=1024*1024}) = 0
prlimit64(0, RLIMIT_NOFILE, {rlim_cur=3211, rlim_max=1050763}, NULL) = -1 EPERM (Operation not permitted)
setrlimit: Operation not permitted
set_rlimit failed
Trace failed with error
+++ exited with 1 +++
```

In [getrlimit(2)](https://www.man7.org/linux/man-pages/man2/getrlimit.2.html), rlim_cur (soft limit) and rlim_max (hard limit) is described as follows:

> The soft limit is the value that the kernel enforces for the corre‐
> sponding resource.  The hard limit acts as a ceiling for the soft
> limit: an unprivileged process may set only its soft limit to a value
> in the range from 0 up to the hard limit, and (irreversibly) lower
> its hard limit.  A privileged process (under Linux: one with the
> CAP_SYS_RESOURCE capability in the initial user namespace) may make
> arbitrary changes to either limit value.

so there is no need to update rlim_max if rlim_cur <= rlim_max.

